### PR TITLE
Auto populate times

### DIFF
--- a/app/models/prescription.rb
+++ b/app/models/prescription.rb
@@ -19,8 +19,8 @@ class Prescription < ApplicationRecord
   before_validation :set_doses_remaining, on: :create
 
   private
-    def set_doses_remaining
-      self.doses_remaining = self.total_doses
-    end
 
+  def set_doses_remaining
+    self.doses_remaining = total_doses
+  end
 end

--- a/db/migrate/20220710163021_create_prescriptions.rb
+++ b/db/migrate/20220710163021_create_prescriptions.rb
@@ -7,8 +7,8 @@ class CreatePrescriptions < ActiveRecord::Migration[5.2]
   def change
     create_table :prescriptions do |t|
       t.string :med_name
-      t.datetime :time_of_last_dose, :default => Time.now
-      t.datetime :time_of_next_dose, :default => Time.now
+      t.datetime :time_of_last_dose, default: Time.now
+      t.datetime :time_of_next_dose, default: Time.now
       t.integer :total_doses
       t.integer :doses_remaining
       t.integer :max_daily_doses

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,46 +12,45 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_11_204711) do
-
+ActiveRecord::Schema.define(version: 20_220_711_204_711) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "notifications", force: :cascade do |t|
-    t.string "recipient"
-    t.datetime "sent_at"
-    t.string "notification_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'notifications', force: :cascade do |t|
+    t.string 'recipient'
+    t.datetime 'sent_at'
+    t.string 'notification_type'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "prescriptions", force: :cascade do |t|
-    t.string "med_name"
-    t.datetime "time_of_last_dose", default: "2022-07-18 13:18:36"
-    t.datetime "time_of_next_dose", default: "2022-07-18 13:18:36"
-    t.integer "total_doses"
-    t.integer "doses_remaining"
-    t.integer "max_daily_doses"
-    t.string "dose"
-    t.text "user_instructions"
-    t.text "additional_instructions"
-    t.integer "time_between_dose"
-    t.string "icon"
-    t.bigint "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_prescriptions_on_user_id"
+  create_table 'prescriptions', force: :cascade do |t|
+    t.string 'med_name'
+    t.datetime 'time_of_last_dose', default: '2022-07-18 13:18:36'
+    t.datetime 'time_of_next_dose', default: '2022-07-18 13:18:36'
+    t.integer 'total_doses'
+    t.integer 'doses_remaining'
+    t.integer 'max_daily_doses'
+    t.string 'dose'
+    t.text 'user_instructions'
+    t.text 'additional_instructions'
+    t.integer 'time_between_dose'
+    t.string 'icon'
+    t.bigint 'user_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_prescriptions_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "first_name"
-    t.string "last_name"
-    t.string "email"
-    t.string "sms"
-    t.integer "notify", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'users', force: :cascade do |t|
+    t.string 'first_name'
+    t.string 'last_name'
+    t.string 'email'
+    t.string 'sms'
+    t.integer 'notify', default: 0
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  add_foreign_key "prescriptions", "users"
+  add_foreign_key 'prescriptions', 'users'
 end

--- a/spec/models/prescription_spec.rb
+++ b/spec/models/prescription_spec.rb
@@ -20,15 +20,14 @@ RSpec.describe Prescription, type: :model do
   describe '#set_doses_remaining' do
     it 'auto-populates set_doses_remaining to total_doses' do
       user = User.create!(id: 1, first_name: 'John', last_name: 'L', email: 'John.L@email.com',
-                   sms: '5551234567', notify: 3)
+                          sms: '5551234567', notify: 3)
 
       rx = Prescription.create!(user_id: user.id, med_name: 'Tylenol', total_doses: 500,
-                           max_daily_doses: 6, dose: '200 mg', user_instructions: 'take pill, take with food',
-                           additional_instructions: 'take 2 call me in the morning', time_between_dose: 240,
-                           icon: 'path_to_icon')
+                                max_daily_doses: 6, dose: '200 mg', user_instructions: 'take pill, take with food',
+                                additional_instructions: 'take 2 call me in the morning', time_between_dose: 240,
+                                icon: 'path_to_icon')
 
-    expect(rx.doses_remaining).to eq(rx.total_doses)
-
+      expect(rx.doses_remaining).to eq(rx.total_doses)
     end
   end
 end


### PR DESCRIPTION
### Description

Adds auto-populate logic for the prescription table.  On create time_of_last_dose and time_of_next_dose are set to current time.  sets doses_remaining to totatl_doses

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
